### PR TITLE
Automate database connection in init-postgres-salesdb.sql script with \connect

### DIFF
--- a/datasets/postgres/init-postgres-salesdb.sql
+++ b/datasets/postgres/init-postgres-salesdb.sql
@@ -9,10 +9,7 @@
 -- DROP AND CREATE DATABASE
 DROP DATABASE IF EXISTS salesdb;
 CREATE DATABASE salesdb;
-
--- Connect to the new database (manual step in most PostgreSQL tools)
-
--- Now switch to the salesdb database to execute the following
+\connect salesdb;
 
 -- Create schema
 DROP SCHEMA IF EXISTS sales CASCADE;


### PR DESCRIPTION
This PR updates the `salesdb` database setup script to streamline execution by replacing manual database connection instructions with a single automated command.

Changes:
    Removed comments instructing users to manually connect to `salesdb`.
    Added `\connect salesdb` after creating the database.
